### PR TITLE
Remove no-deamon flag from pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 -   id: pydevf
     name: PyDev Formatter
     description: PyDev Code Formatter    
-    entry: pydevf --no-daemon
+    entry: pydevf
     language: python
     files: \.(py|pyw)$


### PR DESCRIPTION
Change the default behaviour of pre-commit hook to enable the Daemon.
pydevf hook users can still add the no-deamon flag when declaring
the plugin on pre-commit config.